### PR TITLE
Update Get-WebCertificate function to work in new .NET Versions

### DIFF
--- a/Network/Network.psd1
+++ b/Network/Network.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Network.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.9.2.1'
+    ModuleVersion     = '0.9.2.2'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -168,6 +168,9 @@ Version 0.9.2
 
 Version 0.9.2.1
 - Function : Changed : Set-WebSecurityProtocol. TLS 1.3 protocol added
+
+Version 0.9.2.2
+- Function : Changed : Get-WebCertificate. Replaced deprecated [Net.HttpWebRequest] with TcpClient and SslStream.
 '
 
             # External dependent modules of this module


### PR DESCRIPTION
Due to the changes to [Net.HttpWebRequest], it no longer returns certificate information with the request.

To fix this, we must replace the usage of [Net.HttpWebRequest] with a method using System.Net.Sockets.TcpClient and System.Net.Security.SslStream. This approach allows us to directly establish a TCP connection to the target server and retrieve its SSL/TLS certificate using SslStream.RemoteCertificate.

This solution works in PowerShell 7, and Windows Powershell 5.1. Additionally, these changes ensure cross-platform compatibility, as it uses .NET Core's supported classes.

To learn more about the deprecation of this class please checkout these links:

    https://learn.microsoft.com/en-us/dotnet/api/system.net.httpwebrequest?view=net-8.0
    https://learn.microsoft.com/en-us/dotnet/core/compatibility/networking/6.0/webrequest-deprecated